### PR TITLE
Use offensive instead of separate algorithm

### DIFF
--- a/lib/obscenity/base.rb
+++ b/lib/obscenity/base.rb
@@ -29,12 +29,7 @@ module Obscenity
       end
 
       def profane?(text)
-        return false unless text.to_s.size >= 3
-        text.split.each do |piece|
-          next if piece =~ whitelist_pattern
-          return true if piece =~ blacklist_pattern
-        end
-        false
+        !offensive(text).empty?
       end
 
       def sanitize(text)


### PR DESCRIPTION
The issue here was the `profane?` algorithm flagged words
that were not actually offensive.
Specifically, it flagged any string more than 2 characters long
that contained `"as"` as profane.
Whereas, the same string did not contain any offensive characters.

These two methods should agree on their logic of which words are
offensive and profane.
