### PR TITLE
Short words should not be flagged as offensive

### DIFF
--- a/config/blacklist.yml
+++ b/config/blacklist.yml
@@ -204,7 +204,6 @@
 - dangleberry
 - deez nuts
 - devil
-- dick
 - dick breath
 - dick fiend
 - dick head

--- a/lib/obscenity/base.rb
+++ b/lib/obscenity/base.rb
@@ -80,6 +80,7 @@ module Obscenity
       end
 
       def offensive_word?(word)
+        return false unless word.size >= 3
         return false if word =~ whitelist_pattern
         return true if word =~ blacklist_pattern
         false

--- a/lib/obscenity/base.rb
+++ b/lib/obscenity/base.rb
@@ -31,8 +31,7 @@ module Obscenity
       def profane?(text)
         return false unless text.to_s.size >= 3
         text.split.each do |piece|
-          next if piece =~ whitelist_pattern
-          return true if piece =~ blacklist_pattern
+          return true if offensive_word? piece
         end
         false
       end
@@ -54,8 +53,8 @@ module Obscenity
       def offensive(text)
         words = []
         return(words) unless text.to_s.size >= 3
-        blacklist.each do |foul|
-          words << foul if text =~ /\b#{foul}\b/i && !whitelist.include?(foul)
+        text.split.each do |piece|
+          words << piece if offensive_word? piece
         end
         words.uniq
       end
@@ -80,6 +79,11 @@ module Obscenity
         end
       end
 
+      def offensive_word?(word)
+        return false if word =~ whitelist_pattern
+        return true if word =~ blacklist_pattern
+        false
+      end
     end
   end
 end

--- a/lib/obscenity/base.rb
+++ b/lib/obscenity/base.rb
@@ -29,7 +29,12 @@ module Obscenity
       end
 
       def profane?(text)
-        !offensive(text).empty?
+        return false unless text.to_s.size >= 3
+        text.split.each do |piece|
+          next if piece =~ whitelist_pattern
+          return true if piece =~ blacklist_pattern
+        end
+        false
       end
 
       def sanitize(text)

--- a/lib/obscenity/base.rb
+++ b/lib/obscenity/base.rb
@@ -81,7 +81,7 @@ module Obscenity
 
       def offensive_word?(word)
         return false unless word.size >= 3
-        return false if word =~ whitelist_pattern
+        return false if !whitelist.empty? && word =~ whitelist_pattern
         return true if word =~ blacklist_pattern
         false
       end

--- a/lib/obscenity/base.rb
+++ b/lib/obscenity/base.rb
@@ -21,11 +21,11 @@ module Obscenity
       end
 
       def blacklist_pattern
-        @blacklist_pattern ||= /\b(#{blacklist.map {|a| "(?:#{a})"}.join('|')})\b/i
+        @blacklist_pattern ||= /(\b|\W|\A)(#{blacklist.map {|a| "(?:#{Regexp.escape(a)})"}.join('|')})(\b|\W|\z)/i
       end
 
       def whitelist_pattern
-        @whitelist_pattern ||= /\b(#{whitelist.map {|a| "(?:#{a})"}.join('|')})\b/
+        @whitelist_pattern ||= /(\b|\W|\A)(#{whitelist.map {|a| "(?:#{Regexp.escape(a)})"}.join('|')})(\b|\W|\z)/
       end
 
       def profane?(text)

--- a/lib/obscenity/config.rb
+++ b/lib/obscenity/config.rb
@@ -3,7 +3,7 @@ module Obscenity
     
     attr_accessor :replacement
     
-    DEFAULT_WHITELIST = ['Dick']
+    DEFAULT_WHITELIST = []
     DEFAULT_BLACKLIST = File.dirname(__FILE__) + "/../../config/blacklist.yml"
     
     def initialize

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -203,14 +203,14 @@ class TestBase < Test::Unit::TestCase
           Obscenity::Base.whitelist = :default
         }
         should "return an array with the offensive words based on the default list" do
-          assert_equal ['assclown'], Obscenity::Base.offensive('Yo assclown, sup')
+          assert_equal ['assclown,'], Obscenity::Base.offensive('Yo assclown, sup')
           assert_equal [], Obscenity::Base.offensive('Hello world')
         end
       end
       context "with custom blacklist config" do
         setup { Obscenity::Base.blacklist = ['yo', 'word'] }
         should "return an array with the offensive words based on a custom list" do
-          assert_equal ['yo', 'word'], Obscenity::Base.offensive('Yo word, sup')
+          assert_equal ['Yo', 'word,'], Obscenity::Base.offensive('Yo word, sup')
           assert_equal [], Obscenity::Base.offensive('Hello world')
         end
       end
@@ -222,7 +222,7 @@ class TestBase < Test::Unit::TestCase
           Obscenity::Base.whitelist = ['biatch']
         }
         should "return an array with the offensive words based on the default blacklist and custom whitelist" do
-          assert_equal ['assclown'], Obscenity::Base.offensive('Yo assclown, sup')
+          assert_equal ['assclown,'], Obscenity::Base.offensive('Yo assclown, sup')
           assert_equal [], Obscenity::Base.offensive('Yo biatch, sup')
         end
       end
@@ -232,7 +232,7 @@ class TestBase < Test::Unit::TestCase
           Obscenity::Base.whitelist = ['biatch']
         }
         should "return an array with the offensive words based on the custom list" do
-          assert_equal ['clown'], Obscenity::Base.offensive('Yo clown, sup')
+          assert_equal ['clown,'], Obscenity::Base.offensive('Yo clown, sup')
           assert_equal [], Obscenity::Base.offensive('Yo biatch, sup')
         end
       end

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -64,10 +64,19 @@ class TestBase < Test::Unit::TestCase
         end
       end
       context "with custom blacklist config including a short word" do
-        setup { Obscenity::Base.blacklist = ['as$'] }
+        setup { Obscenity::Base.blacklist = ['as'] }
         should "ignore short words" do
           assert !Obscenity::Base.profane?('such as you')
+        end
+      end
+      context "with custom blacklist config including a regexy word" do
+        setup { Obscenity::Base.blacklist = ['as$', 'a$s'] }
+        should "treat it as a raw string" do
+          assert !Obscenity::Base.profane?('such as you')
           assert !Obscenity::Base.profane?('as')
+          assert !Obscenity::Base.profane?('christmas')
+          assert Obscenity::Base.profane?('as$')
+          assert Obscenity::Base.profane?('a$s')
         end
       end
     end

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -63,6 +63,13 @@ class TestBase < Test::Unit::TestCase
           assert !Obscenity::Base.profane?('biatch')
         end
       end
+      context "with custom blacklist config including a short word" do
+        setup { Obscenity::Base.blacklist = ['as$'] }
+        should "ignore short words" do
+          assert !Obscenity::Base.profane?('such as you')
+          assert !Obscenity::Base.profane?('as')
+        end
+      end
     end
     context "with whitelist" do
       context "without custom blacklist config" do
@@ -208,9 +215,9 @@ class TestBase < Test::Unit::TestCase
         end
       end
       context "with custom blacklist config" do
-        setup { Obscenity::Base.blacklist = ['yo', 'word'] }
+        setup { Obscenity::Base.blacklist = ['yoyo', 'word'] }
         should "return an array with the offensive words based on a custom list" do
-          assert_equal ['Yo', 'word,'], Obscenity::Base.offensive('Yo word, sup')
+          assert_equal ['Yoyo', 'word,'], Obscenity::Base.offensive('Yoyo word, sup')
           assert_equal [], Obscenity::Base.offensive('Hello world')
         end
       end


### PR DESCRIPTION
Also,
- Reverts the commit that updates the defaults config with our own words
- Now uses the same logic when detecting profanity and extracting a list of offensive words
  - `#sanitize` is not covered
- Escapes special Regexp characters and does a broader matching of words
